### PR TITLE
Simplified Haskell eeeeeeeeeeeeeeee

### DIFF
--- a/e.hs
+++ b/e.hs
@@ -1,3 +1,2 @@
-import Control.Monad.Fix
+import Data.Function
 main = putStr $ fix ('e':)
-


### PR DESCRIPTION
Mostly a cosmetic change, but the haskell eeeee should probably import from `Data.Function`, and not `Control.Monad.Fix`.  Unless the fun is in the absurdity of pulling in a redundant monad module just for eeeeeeeeee. :)