### PR TITLE
[CMake] Fix for out-of-sourceeeeeeeeeeeeeee build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,5 +2,5 @@ cmake_minimum_required (VERSION 2.6)
 project (eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee)
 message("eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee")
 add_executable(eeeee e.c)
-add_custom_command(TARGET eeeee POST_BUILD COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/eeeee)
+add_custom_command(TARGET eeeee POST_BUILD COMMAND ${CMAKE_CURRENT_BINARY_DIR}/eeeee)
 


### PR DESCRIPTION
${CMAKE_CURRENT_SOURCE_DIR} meaning source dir. Using it makes failing to find eeeee excutable binary when out-of-source building. Instead using ${CMAKE_CURRENT_BINARY_DIR}.