### PR TITLE
Update e.red

### DIFF
--- a/e.red
+++ b/e.red
@@ -1,4 +1,1 @@
-Red []
-while [1][
-    print "E"
-]
+Red [] forever [prin "e"]


### PR DESCRIPTION
`print` adds newline between "e"s. `prin` is correct. `forever` is clearer intent than `while [1]`.